### PR TITLE
fix webView flash

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,6 +76,8 @@ function WebUI (context, htmlName, options) {
     webView.setUIDelegate_(uiDelegate.getClassInstance())
   }
 
+  webView.setOpaque(true)
+  webView.setBackgroundColor(options.background || NSColor.whiteColor())
   webView.setMainFrameURL_(context.plugin.urlForResourceNamed(htmlName).path())
 
   panel.contentView().addSubview(webView)

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ function WebUI (context, htmlName, options) {
   // ColorPicker main window
   var identifier = options.identifier || NSUUID.UUID().UUIDString()
   var threadDictionary = NSThread.mainThread().threadDictionary()
-
+  var backgroundColor = options.background || NSColor.whiteColor()
   var panel = threadDictionary[identifier] ? threadDictionary[identifier] : NSPanel.alloc().init()
 
   // Window size
@@ -22,7 +22,7 @@ function WebUI (context, htmlName, options) {
   ), true)
 
   panel.setStyleMask(options.styleMask || (NSTexturedBackgroundWindowMask | NSTitledWindowMask | NSClosableWindowMask))
-  panel.setBackgroundColor(options.background || NSColor.whiteColor())
+  panel.setBackgroundColor(backgroundColor)
 
   if (options.onlyShowCloseButton) {
     panel.standardWindowButton(NSWindowMiniaturizeButton).setHidden(true)
@@ -77,7 +77,7 @@ function WebUI (context, htmlName, options) {
   }
 
   webView.setOpaque(true)
-  webView.setBackgroundColor(options.background || NSColor.whiteColor())
+  webView.setBackgroundColor(backgroundColor)
   webView.setMainFrameURL_(context.plugin.urlForResourceNamed(htmlName).path())
 
   panel.contentView().addSubview(webView)


### PR DESCRIPTION
Hi,
A fix to prevent the webView from 'flashing white' before the html content is loaded. 
Only visible when using a custom NSColor in options.background.
This PR sets the webView's background colour to match the same colour as the Window. 