### PR TITLE
Allow websites in addition to files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,11 @@ function WebUI (context, htmlName, options) {
 
   webView.setOpaque(true)
   webView.setBackgroundColor(backgroundColor)
-  webView.setMainFrameURL_(context.plugin.urlForResourceNamed(htmlName).path())
+  if (/^http/.test(htmlName)) {
+    webView.setMainFrameURL_(htmlName);
+  } else {
+    context.plugin.urlForResourceNamed(htmlName).path();
+  }
 
   panel.contentView().addSubview(webView)
   panel.center()


### PR DESCRIPTION
I'll start with a disclaimer that this may be a bad idea and I won't be offended if you insta-close :)

I'm building a Sketch panel with a React app, which in dev gets served from localhost rather than a file in the file system (at least not without some seemingly very nontrivial configuration changes). While there will be actual files to work with in the published version, I need to be able to point to the devserver in development mode. Sketch web view specifically only supports files in the plugin right now, so this adds the option to use a url instead.